### PR TITLE
RFC: Burst support

### DIFF
--- a/wishbone-tool/.cargo/config
+++ b/wishbone-tool/.cargo/config
@@ -1,8 +1,6 @@
-[target.armv7-unknown-linux-gnueabihf]
-linker = "arm-linux-gnueabihf-gcc-4.7"
 
 [target.armv7-unknown-linux-musleabihf]
-linker = "arm-linux-gnueabihf-gcc-4.7"
+linker = "arm-linux-musleabihf-gcc"
 
 # This doesn't seem to actually work, so you may need to
 # export AR="arm-linux-musleabihf-ar"

--- a/wishbone-tool/.cargo/config
+++ b/wishbone-tool/.cargo/config
@@ -1,6 +1,8 @@
+[target.armv7-unknown-linux-gnueabihf]
+linker = "arm-linux-gnueabihf-gcc-4.7"
 
 [target.armv7-unknown-linux-musleabihf]
-linker = "arm-linux-musleabihf-gcc"
+linker = "arm-linux-gnueabihf-gcc-4.7"
 
 # This doesn't seem to actually work, so you may need to
 # export AR="arm-linux-musleabihf-ar"

--- a/wishbone-tool/crates/bridge/src/bridges/usb.rs
+++ b/wishbone-tool/crates/bridge/src/bridges/usb.rs
@@ -88,6 +88,7 @@ enum ConnectThreadRequests {
     Poke(u32 /* addr */, u32 /* val */),
     Peek(u32 /* addr */),
     BurstRead(u32 /* addr */, u32 /* len */),
+    BurstWrite(u32 /* addr */, Vec<u8> /* write data */)
 }
 
 #[derive(Debug)]
@@ -95,6 +96,7 @@ enum ConnectThreadResponses {
     OpenedDevice,
     PeekResult(Result<u32, BridgeError>),
     BurstReadResult(Result<Vec<u8>, BridgeError>),
+    BurstWriteResult(Result<(), BridgeError>),
     PokeResult(Result<(), BridgeError>),
     Exiting,
 }
@@ -260,6 +262,13 @@ impl UsbBridgeInner {
                                         Some(ConnectThreadResponses::BurstReadResult(result));
                                     cvar.notify_one();
                                 }
+                                ConnectThreadRequests::BurstWrite(addr, data) => {
+                                    let result = Self::do_burst_write(&usb, addr, data, debug_byte);
+                                    keep_going = result.is_ok();
+                                    *response.lock().unwrap() =
+                                        Some(ConnectThreadResponses::BurstWriteResult(result));
+                                    cvar.notify_one();
+                                }
                             },
                         }
                     }
@@ -305,7 +314,13 @@ impl UsbBridgeInner {
                             cfg.vid = v;
                         }
                         ConnectThreadRequests::BurstRead(_addr, _len) => {
-                            *response.lock().unwrap() = Some(ConnectThreadResponses::PokeResult(
+                            *response.lock().unwrap() = Some(ConnectThreadResponses::BurstReadResult(
+                                Err(BridgeError::NotConnected),
+                            ));
+                            cvar.notify_one();
+                        }
+                        ConnectThreadRequests::BurstWrite(_addr, _data) => {
+                            *response.lock().unwrap() = Some(ConnectThreadResponses::BurstWriteResult(
                                 Err(BridgeError::NotConnected),
                             ));
                             cvar.notify_one();
@@ -352,6 +367,56 @@ impl UsbBridgeInner {
                 }
             }
         }
+    }
+
+    fn do_burst_write(
+        usb: &libusb_wishbone_tool::DeviceHandle,
+        addr: u32,
+        data: Vec<u8>,
+        debug_byte: u8,
+    ) -> Result<(), BridgeError> {
+        if data.len() == 0 {
+            return Ok(());
+        }
+
+        let maxlen = 4096; // spec says...1023 max? but 4096 works.
+
+        let packet_count = data.len() / maxlen + if (data.len() % maxlen) != 0 { 1 } else { 0 };
+        for pkt_num in 0..packet_count {
+            let cur_addr = addr as usize + pkt_num * maxlen;
+            let bufsize = if pkt_num  == (packet_count - 1) {
+                if data.len() % maxlen != 0 {
+                    data.len() % maxlen
+                } else {
+                    maxlen
+                }
+            } else {
+                maxlen
+            };
+            match usb.write_control(
+                debug_byte,
+                0,
+                (cur_addr & 0xffff) as u16,
+                ((cur_addr >> 16) & 0xffff) as u16,
+                &data[pkt_num * maxlen..pkt_num * maxlen + bufsize],
+                Duration::from_millis(500),
+            ) {
+                Err(e) => {
+                    debug!("BURST_WRITE @ {:08x}: usb error {:?}", addr, e);
+                    return Err(BridgeError::USBError(e));
+                }
+                Ok(retlen) => {
+                    if retlen != bufsize as usize {
+                        debug!(
+                            "BURST_WRITE @ {:08x}: length error: expected {} bytes, got {} bytes",
+                            addr, bufsize, retlen
+                        );
+                        return Err(BridgeError::LengthError(bufsize as usize, retlen));
+                    }
+                }
+            }
+        }
+        Ok(())
     }
 
     fn do_peek(
@@ -434,9 +499,9 @@ impl UsbBridgeInner {
                     if retlen != bufsize as usize {
                         debug!(
                             "BURST_READ @ {:08x}: length error: expected {} bytes, got {} bytes",
-                            addr, len, retlen
+                            addr, bufsize, retlen
                         );
-                        return Err(BridgeError::LengthError(len as usize, retlen));
+                        return Err(BridgeError::LengthError(bufsize as usize, retlen));
                     } else {
                         for i in 0..data_val.len() {
                             if (i % 16) == 0 {
@@ -495,7 +560,7 @@ impl UsbBridgeInner {
         let mut _mtx = lock.lock().unwrap();
         self.main_tx
             .send(ConnectThreadRequests::BurstRead(addr, len))
-            .expect("Unable to send peek to connect thread");
+            .expect("Unable to send burst read to connect thread");
         *_mtx = None;
         while _mtx.is_none() {
             _mtx = cvar.wait(_mtx).unwrap();
@@ -503,7 +568,27 @@ impl UsbBridgeInner {
         match _mtx.take() {
             Some(ConnectThreadResponses::BurstReadResult(r)) => Ok(r?),
             e => {
-                error!("unexpected bridge peek response: {:?}", e);
+                error!("unexpected bridge burst reed response: {:?}", e);
+                Err(BridgeError::WrongResponse)
+            }
+        }
+    }
+
+    pub fn burst_write(&self, addr: u32, data: &Vec<u8>) -> Result<(), BridgeError> {
+        let &(ref lock, ref cvar) = &*self.main_rx;
+        let mut _mtx = lock.lock().unwrap();
+        let local_data = data.to_vec();
+        self.main_tx
+            .send(ConnectThreadRequests::BurstWrite(addr, local_data))
+            .expect("Unable to send burst write to connect thread");
+        *_mtx = None;
+        while _mtx.is_none() {
+            _mtx = cvar.wait(_mtx).unwrap();
+        }
+        match _mtx.take() {
+            Some(ConnectThreadResponses::BurstWriteResult(r)) => Ok(r?),
+            e => {
+                error!("unexpected bridge burst write response: {:?}", e);
                 Err(BridgeError::WrongResponse)
             }
         }

--- a/wishbone-tool/crates/bridge/src/bridges/usb.rs
+++ b/wishbone-tool/crates/bridge/src/bridges/usb.rs
@@ -403,17 +403,19 @@ impl UsbBridgeInner {
             return Ok(data_val);
         }
 
-        let packet_count = len / 64 + if (len % 64) != 0 { 1 } else { 0 };
+        let maxlen = 4096; // spec says...1023 max? but 4096 works.
+
+        let packet_count = len / maxlen + if (len % maxlen) != 0 { 1 } else { 0 };
         for pkt_num in 0..packet_count {
-            let cur_addr = addr + pkt_num * 64;
+            let cur_addr = addr + pkt_num * maxlen;
             let bufsize = if pkt_num  == (packet_count - 1) {
-                if len % 64 != 0 {
-                    len % 64
+                if len % maxlen != 0 {
+                    len % maxlen
                 } else {
-                    64
+                    maxlen
                 }
             } else {
-                64
+                maxlen
             };
             let mut buffer = vec![0; bufsize as usize];
             match usb.read_control(

--- a/wishbone-tool/crates/bridge/src/lib.rs
+++ b/wishbone-tool/crates/bridge/src/lib.rs
@@ -339,4 +339,33 @@ impl Bridge {
             }
         }
     }
+
+    pub fn burst_read(&self, addr: u32, length: u32) -> Result<Vec<u8>, BridgeError> {
+        let _mtx = self.mutex.lock().unwrap();
+        loop {
+            let result = match &self.core {
+                #[cfg(feature = "ethernet")]
+                BridgeCore::EthernetBridge(_b) => return Err(BridgeError::ProtocolNotSupported),
+                #[cfg(feature = "pcie")]
+                BridgeCore::PCIeBridge(_b) => return Err(BridgeError::ProtocolNotSupported),
+                #[cfg(feature = "spi")]
+                BridgeCore::SpiBridge(_b) => return Err(BridgeError::ProtocolNotSupported),
+                #[cfg(feature = "uart")]
+                BridgeCore::UartBridge(_b) => return Err(BridgeError::ProtocolNotSupported),
+                #[cfg(feature = "usb")]
+                BridgeCore::UsbBridge(b) => b.burst_read(addr, length),
+            };
+            #[allow(unreachable_code)] // Only possible when no features are enabled (compile error)
+            if let Err(e) = result {
+                #[cfg(feature = "usb")]
+                if let BridgeError::USBError(libusb_wishbone_tool::Error::Pipe) = e {
+                    debug!("USB device disconnected, forcing early return");
+                    return Err(e);
+                }
+                debug!("Peek failed, trying again: {:?}", e);
+            } else {
+                return result;
+            }
+        }
+    }
 }

--- a/wishbone-tool/crates/bridge/src/lib.rs
+++ b/wishbone-tool/crates/bridge/src/lib.rs
@@ -368,4 +368,33 @@ impl Bridge {
             }
         }
     }
+
+    pub fn burst_write(&self, addr: u32, data: &Vec<u8>) -> Result<(), BridgeError> {
+        let _mtx = self.mutex.lock().unwrap();
+        loop {
+            let result = match &self.core {
+                #[cfg(feature = "ethernet")]
+                BridgeCore::EthernetBridge(_b) => return Err(BridgeError::ProtocolNotSupported),
+                #[cfg(feature = "pcie")]
+                BridgeCore::PCIeBridge(_b) => return Err(BridgeError::ProtocolNotSupported),
+                #[cfg(feature = "spi")]
+                BridgeCore::SpiBridge(_b) => return Err(BridgeError::ProtocolNotSupported),
+                #[cfg(feature = "uart")]
+                BridgeCore::UartBridge(_b) => return Err(BridgeError::ProtocolNotSupported),
+                #[cfg(feature = "usb")]
+                BridgeCore::UsbBridge(b) => b.burst_write(addr, data),
+            };
+            #[allow(unreachable_code)] // Only possible when no features are enabled (compile error)
+            if let Err(e) = result {
+                #[cfg(feature = "usb")]
+                if let BridgeError::USBError(libusb_wishbone_tool::Error::Pipe) = e {
+                    debug!("USB device disconnected, forcing early return");
+                    return Err(e);
+                }
+                debug!("Peek failed, trying again: {:?}", e);
+            } else {
+                return result;
+            }
+        }
+    }
 }

--- a/wishbone-tool/crates/core/config.rs
+++ b/wishbone-tool/crates/core/config.rs
@@ -104,6 +104,7 @@ pub struct Config {
     pub terminal_mouse: bool,
     pub burst_length: u32,
     pub hexdump: bool,
+    pub burst_source: Option<String>,
 }
 
 impl Default for Config {
@@ -126,6 +127,7 @@ impl Default for Config {
             terminal_mouse: false,
             burst_length: 4,
             hexdump: false,
+            burst_source: None,
         }
     }
 }
@@ -354,6 +356,8 @@ impl Config {
         let terminal_mouse = matches.is_present("terminal-mouse") || cfg!(windows);
         let hexdump = matches.is_present("hexdump");
 
+        let burst_source = matches.value_of("burst-source").map(|n| n.to_owned());
+
         Ok((
             Config {
                 memory_address,
@@ -373,6 +377,7 @@ impl Config {
                 terminal_mouse,
                 burst_length,
                 hexdump,
+                burst_source,
             },
             bridge,
         ))

--- a/wishbone-tool/crates/core/config.rs
+++ b/wishbone-tool/crates/core/config.rs
@@ -103,6 +103,7 @@ pub struct Config {
     pub load_addr: Option<u32>,
     pub terminal_mouse: bool,
     pub burst_length: u32,
+    pub hexdump: bool,
 }
 
 impl Default for Config {
@@ -124,6 +125,7 @@ impl Default for Config {
             load_addr: None,
             terminal_mouse: false,
             burst_length: 4,
+            hexdump: false,
         }
     }
 }
@@ -350,6 +352,7 @@ impl Config {
         }
 
         let terminal_mouse = matches.is_present("terminal-mouse") || cfg!(windows);
+        let hexdump = matches.is_present("hexdump");
 
         Ok((
             Config {
@@ -369,6 +372,7 @@ impl Config {
                 load_addr,
                 terminal_mouse,
                 burst_length,
+                hexdump,
             },
             bridge,
         ))

--- a/wishbone-tool/crates/core/config.rs
+++ b/wishbone-tool/crates/core/config.rs
@@ -102,6 +102,7 @@ pub struct Config {
     pub load_name: Option<String>,
     pub load_addr: Option<u32>,
     pub terminal_mouse: bool,
+    pub burst_length: u32,
 }
 
 impl Default for Config {
@@ -122,6 +123,7 @@ impl Default for Config {
             load_name: None,
             load_addr: None,
             terminal_mouse: false,
+            burst_length: 4,
         }
     }
 }
@@ -242,6 +244,7 @@ impl Config {
         // unwrap() is safe because there is a default value
         let gdb_port = parse_u16(matches.value_of("gdb-port").unwrap())?;
         let bind_port = parse_u16(matches.value_of("wishbone-port").unwrap())?;
+        let burst_length = parse_u32(matches.value_of("burst-length").unwrap())?;
 
         let bind_addr = matches
             .value_of("bind-addr")
@@ -365,6 +368,7 @@ impl Config {
                 load_name,
                 load_addr,
                 terminal_mouse,
+                burst_length,
             },
             bridge,
         ))

--- a/wishbone-tool/crates/core/main.rs
+++ b/wishbone-tool/crates/core/main.rs
@@ -270,6 +270,15 @@ fn clap_app<'a, 'b>() -> App<'a, 'b> {
                 .display_order(26)
                 .takes_value(true),
         )
+
+        .arg(
+            Arg::with_name("burst-length")
+            .long("burst-length")
+            .help("Number of bytes in a burst (implies burst operation)")
+            .default_value("4")
+            .display_order(27)
+            .takes_value(true),
+        )
 }
 
 fn main() -> Result<(), String> {

--- a/wishbone-tool/crates/core/main.rs
+++ b/wishbone-tool/crates/core/main.rs
@@ -279,6 +279,14 @@ fn clap_app<'a, 'b>() -> App<'a, 'b> {
             .display_order(27)
             .takes_value(true),
         )
+
+        .arg(
+            Arg::with_name("hexdump")
+            .long("hexdump")
+            .help("In conjunction with burst-length, report reads as text hexdumps, instead of binary data")
+            .display_order(28)
+            .takes_value(false),
+        )
 }
 
 fn main() -> Result<(), String> {

--- a/wishbone-tool/crates/core/main.rs
+++ b/wishbone-tool/crates/core/main.rs
@@ -281,6 +281,14 @@ fn clap_app<'a, 'b>() -> App<'a, 'b> {
         )
 
         .arg(
+            Arg::with_name("burst-source")
+            .long("burst-source")
+            .help("File for burst data input when sending data to device")
+            .display_order(29)
+            .takes_value(true),
+        )
+
+        .arg(
             Arg::with_name("hexdump")
             .long("hexdump")
             .help("In conjunction with burst-length, report reads as text hexdumps, instead of binary data")

--- a/wishbone-tool/crates/core/server/mod.rs
+++ b/wishbone-tool/crates/core/server/mod.rs
@@ -392,14 +392,19 @@ pub fn memory_access(cfg: &Config, bridge: Bridge) -> Result<(), ServerError> {
                 let page = bridge.burst_read(addr, cfg.burst_length);
                 match page {
                     Ok(array) => {
-                        for i in 0..array.len() {
-                            if (i % 16) == 0 {
-                                println!(""); // carriage return
-                                print!("{:08x}: ", addr as usize + i);
+                        if cfg.hexdump {
+                            for i in 0..array.len() {
+                                if (i % 16) == 0 {
+                                    println!(""); // carriage return
+                                    print!("{:08x}: ", addr as usize + i);
+                                }
+                                print!("{:02x} ", array[i]);
                             }
-                            print!("{:02x} ", array[i]);
+                            println!("");
+                        } else {
+                            use std::io::Write;
+                            io::stdout().write_all(&array)?;
                         }
-                        println!("");
                     },
                     _ => {
                         error!("Error occured reading page");

--- a/wishbone-tool/crates/core/server/mod.rs
+++ b/wishbone-tool/crates/core/server/mod.rs
@@ -401,7 +401,7 @@ pub fn memory_access(cfg: &Config, bridge: Bridge) -> Result<(), ServerError> {
                         if cfg.hexdump {
                             for i in 0..array.len() {
                                 if (i % 16) == 0 {
-                                    println!(""); // carriage return
+                                    println!(); // carriage return
                                     print!("{:08x}: ", addr as usize + i);
                                 }
                                 print!("{:02x} ", array[i]);

--- a/wishbone-tool/crates/core/server/mod.rs
+++ b/wishbone-tool/crates/core/server/mod.rs
@@ -381,9 +381,15 @@ pub fn memory_access(cfg: &Config, bridge: Bridge) -> Result<(), ServerError> {
         if let Some(value) = cfg.memory_value {
             if cfg.burst_length == 4 {
                 bridge.poke(addr, value)?;
-            } else {
-                println!("Burst write not yet implemented");
             }
+        } else if let Some(file_name) = &cfg.burst_source {
+            use std::io::Read;
+            info!("Loading contents of {} to 0x{:08x}", file_name, addr);
+            let mut f = File::open(file_name)?;
+            let mut data: Vec<u8> = vec![];
+            f.read_to_end(&mut data)?;
+            info!("Sending {} bytes", data.len());
+            bridge.burst_write(addr, &data)?;
         } else {
             if cfg.burst_length == 4 {
                 let val = bridge.peek(addr)?;


### PR DESCRIPTION
These are changes I've made so far to support burst-reads in wishbone tool. Conceivably burst-read() can be condensed into peek() by just using length=4 as a special case to go back to some fallback compatibility mode. For now, I've also got a program using the bridge directly to read data from a Precursor device currently doing RNG CI: https://github.com/betrusted-io/bt-rngd/blob/dc9522b22efd932362504ea5a9a3c594535de1e5/src/main.rs#L18

I think what would be great is if some review could be done to these and committed to a branch, which I can then use to base my next set of changes that will enable burst writing.
