### PR TITLE
wishbone-tool: Fix gdb_unescape.

### DIFF
--- a/wishbone-tool/crates/core/gdb.rs
+++ b/wishbone-tool/crates/core/gdb.rs
@@ -92,16 +92,17 @@ pub fn parse_i32(value: &str) -> Result<i32, GdbServerError> {
 }
 
 fn gdb_unescape(input: &[u8]) -> Vec<u8> {
-    let mut out = input.to_vec();
-    out.iter_mut().fold(&mut Vec::new(), |vec_acc, this_u8| {
-        if vec_acc.last() == Some(&(b'}')) {
-            let len = vec_acc.len();
-            vec_acc[len - 1] = *this_u8 ^ 0x20;
+    let mut it = input.iter();
+    let mut out = Vec::new();
+    while let Some(c) = it.next() {
+        if *c == b'}' {
+            if let Some(c) = it.next() {
+                out.push(*c ^ 0x20);
+            }
         } else {
-            vec_acc.push(*this_u8);
+            out.push(*c);
         }
-        vec_acc
-    });
+    }
     out
 }
 


### PR DESCRIPTION
In the original implementation, `out` only contains a copy of the input bytes and the final `vec_acc` is simply discarded at the end. Further, looking back into the accumulator to see if the last byte was an escape byte doesn't work because it doesn't distinguish between whether it is an actual escape byte, or an already unescaped escape byte. Input sequence `7d 5d 00` results in output sequence `20` instead of the expected `7d 00`.

To fix this I've changed the approach from the functional style to simply use a while loop to grab bytes directly from an iterator.

Fixes #44