### PR TITLE
Implement `std::error::Error` for `BridgeError`

### DIFF
--- a/wishbone-tool/crates/bridge/src/lib.rs
+++ b/wishbone-tool/crates/bridge/src/lib.rs
@@ -197,6 +197,8 @@ impl ::std::fmt::Display for BridgeError {
     }
 }
 
+impl std::error::Error for BridgeError {}
+
 #[cfg(feature = "usb")]
 impl std::convert::From<libusb_wishbone_tool::Error> for BridgeError {
     fn from(e: libusb_wishbone_tool::Error) -> BridgeError {


### PR DESCRIPTION
This makes it possible to use `BridgeError` nicely with crates like `anyhow`.

A slightly different way of doing this would've been to implement `source` and return the underlying error for `BridgeError::USBError` and `BridgeError::IoError`; but I believe it's bad practice to both return an error from `source` and print it in the `Display` impl, so I would've had to remove the printing of the underlying errors from there too and I wanted to keep this to the minimum possible changes.