### PR TITLE
wishbone-tool: don't decode rx xover uart as utf-8

### DIFF
--- a/wishbone-tool/crates/core/server/mod.rs
+++ b/wishbone-tool/crates/core/server/mod.rs
@@ -878,7 +878,7 @@ pub fn terminal_client(cfg: &Config, bridge: Bridge) -> Result<(), ServerError> 
                 read_count += 1;
                 char_buffer.push(bridge.peek(xover_rxtx)? as u8);
             }
-            print!("{}", String::from_utf8_lossy(&char_buffer));
+            stdout().write_all(&char_buffer)?;
             stdout().flush().ok();
         }
 


### PR DESCRIPTION
This makes it possible to process non utf-8 data and add support for doing things like:

```sh
# Connect xover uart to pseudo terminal for further processing in standard tools
socat EXEC:"wishbone-tool '-s terminal --csr-csv csr.csv --spi-pins 10,9,11,7'",pty,raw,echo=0 pty,raw,echo=0 &

picocom /dev/pts/5 --imap lfcrlf
```
```sh
# Decode defmt frames.
wishbone-tool -s terminal --csr-csv csr.csv --spi-pins 10,9,11,7 | defmt-print -e firmware.elf
```